### PR TITLE
polish-ui-and-styling-02a0b98b: Polish UI and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,219 +6,237 @@
     <meta name="description" content="Free portable 2P tic tac toe game">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta name="theme-color" content="#145181">
+    <meta name="theme-color" content="#12161e">
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon"
         href="https://cdn3.iconfinder.com/data/icons/essenstial-ultimate-ui/64/tic_tac_toe-512.png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.11.2/css/all.css">
-    <title>Tic Tac Toe-A project made possible by NooberCong</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Luckiest+Guy&family=Inter:wght@400;600;700&display=swap"
+        rel="stylesheet">
+    <title>Tic Tac Toe</title>
     <style>
-        * {
+        :root {
+            --bg:         #12161e;
+            --board-gap:  #1e2738;
+            --cell-bg:    #1a2030;
+            --cell-hover: #202840;
+            --color-x:    #43dde6;
+            --color-o:    #fc5185;
+            --color-gold: #fdcb6e;
+            --panel-bg:   #1e2738;
+            --text:       #e2e8f5;
+            --text-muted: #7a8fa8;
+            --radius-lg:  14px;
+            --radius-md:  10px;
+            --radius-sm:  6px;
+            --ease:       0.15s ease;
+        }
+
+        *, *::before, *::after {
             margin: 0;
             padding: 0;
+            box-sizing: border-box;
+        }
+
+        html::-webkit-scrollbar { display: none; }
+
+        body {
+            font-family: 'Inter', sans-serif;
         }
 
         .App {
             width: 100vw;
             height: 100vh;
             display: flex;
-            justify-content: space-around;
+            justify-content: center;
             align-items: center;
-            background-color: #263442;
+            gap: 2.5rem;
+            background: linear-gradient(145deg, #12161e 0%, #0c1018 100%);
         }
 
-        html::-webkit-scrollbar {
-            display: none;
-        }
-
+        /* ── Game Board ── */
         .table {
-            width: calc(80vh);
-            height: calc(80%);
-            display: flex;
-            justify-content: space-between;
-            flex-wrap: wrap;
-            background-color: #fdcb6e;
-            align-content: space-between;
-        }
-
-        .right {
-            width: calc(100vw - 100vh - 20%);
-            height: 100%;
-            display: flex;
-            flex-direction: column;
-            justify-content: space-around;
-        }
-
-        .result-board {
-            font-family: cursive;
-            width: 100%;
-            height: 60%;
-            box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.5);
-            border-radius: 5px;
-            display: flex;
-            background-color: #1e2a35;
-            font-size: 1.5rem;
-            color: #ffeaa7;
-            justify-content: space-around;
-            flex-direction: column;
-            align-items: center;
-        }
-
-        .result-board .options {
-            display: flex;
-            align-items: flex-end;
-        }
-
-        .play-again-btn {
-            background-color: transparent;
-            padding: 0.3rem 0.6rem;
-            border: 1px solid #fdcb6e;
-            font-size: 1.2rem;
-            font-family: cursive;
-            color: #f0f0f0;
-            margin-right: 1rem;
-            cursor: pointer;
-            outline: none;
-        }
-
-        .result-board .mode {
-            cursor: pointer;
-        }
-
-        .result-board .mode i {
-            padding: 0 0.4rem 0 1rem;
-        }
-
-        .result-board .score {
-            font-size: 2rem;
+            width: min(78vh, 78vw);
+            height: min(78vh, 78vw);
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            grid-template-rows: repeat(3, 1fr);
+            gap: 0.45rem;
+            padding: 0.45rem;
+            background-color: var(--board-gap);
+            border-radius: var(--radius-lg);
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
         }
 
         .square {
-            background-color: #263442;
+            background-color: var(--cell-bg);
             cursor: pointer;
-            width: calc(calc(100% / 3) - 0.2rem);
-            height: calc(calc(100% / 3) - 0.2rem);
+            border-radius: var(--radius-md);
             display: flex;
             align-items: center;
             justify-content: center;
             font-size: 5rem;
             font-family: 'Luckiest Guy', cursive;
+            transition: background-color var(--ease);
+            user-select: none;
         }
 
-
-        @keyframes scaleUp {
-            from {
-                transform: scale(0.1);
-                opacity: 0;
-            }
-
-            to {
-                transform: scale(1);
-                opacity: 1;
-            }
+        .square:hover:not(:has(p)) {
+            background-color: var(--cell-hover);
         }
 
+        /* ── Right Panel ── */
+        .right {
+            width: 260px;
+            display: flex;
+            flex-direction: column;
+            gap: 1.25rem;
+        }
+
+        /* ── Brand ── */
         .brand {
-            width: 100%;
-            height: 15%;
             text-align: center;
         }
 
         .brand span {
-            font-size: 4rem;
-            font-family: cursive;
+            font-size: 3rem;
+            font-family: 'Luckiest Guy', cursive;
+            letter-spacing: 0.03em;
+            text-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
         }
 
-        .brand span:nth-child(1) {
-            color: #fc5185;
+        .brand span:nth-child(1) { color: var(--color-o); }
+        .brand span:nth-child(2) { color: var(--color-x); }
+        .brand span:nth-child(3) { color: var(--color-gold); }
+
+        /* ── Score Panel ── */
+        .result-board {
+            background-color: var(--panel-bg);
+            border-radius: var(--radius-lg);
+            padding: 1.4rem 1.6rem;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+            display: flex;
+            flex-direction: column;
+            gap: 0.9rem;
         }
 
-        .brand span:nth-child(2) {
-            color: #43dde6;
+        .score-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
         }
 
-        .brand span:nth-child(3) {
-            color: #fdcb6e;
+        .score-label {
+            font-size: 0.85rem;
+            font-weight: 700;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        .score-label.x { color: var(--color-x); }
+        .score-label.o { color: var(--color-o); }
+
+        .result-board .score {
+            font-size: 1.9rem;
+            font-weight: 700;
+            color: var(--text);
+            min-width: 2ch;
+            text-align: right;
+        }
+
+        .divider {
+            height: 1px;
+            border: none;
+            background: rgba(255, 255, 255, 0.07);
+        }
+
+        /* ── Options ── */
+        .result-board .options {
+            display: flex;
+            flex-direction: column;
+            gap: 0.65rem;
+            padding-top: 0.25rem;
+        }
+
+        .play-again-btn {
+            width: 100%;
+            padding: 0.55rem 1rem;
+            background: rgba(253, 203, 110, 0.08);
+            border: 1px solid var(--color-gold);
+            border-radius: var(--radius-sm);
+            font-family: 'Inter', sans-serif;
+            font-size: 0.9rem;
+            font-weight: 700;
+            letter-spacing: 0.06em;
+            color: var(--color-gold);
+            cursor: pointer;
+            outline: none;
+            transition: background-color var(--ease), transform var(--ease);
+        }
+
+        .play-again-btn:hover {
+            background: rgba(253, 203, 110, 0.18);
+        }
+
+        .play-again-btn:active {
+            transform: scale(0.97);
+        }
+
+        .result-board .mode {
+            cursor: pointer;
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            gap: 0.45rem;
+            transition: color var(--ease);
+            user-select: none;
+        }
+
+        .result-board .mode:hover {
+            color: var(--text);
+        }
+
+        .result-board .mode i {
+            font-size: 1rem;
+        }
+
+        /* ── Animations ── */
+        @keyframes scaleUp {
+            from { transform: scale(0.1); opacity: 0; }
+            to   { transform: scale(1);   opacity: 1; }
         }
 
         @keyframes fade {
-            0% {
-                opacity: 1;
-            }
-
-            25% {
-                opacity: 0;
-            }
-
-            50% {
-                opacity: 1;
-            }
-
-            75% {
-                opacity: 0;
-            }
-
-            100% {
-                opacity: 1;
-            }
+            0%   { opacity: 1; }
+            25%  { opacity: 0.15; }
+            50%  { opacity: 1; }
+            75%  { opacity: 0.15; }
+            100% { opacity: 1; }
         }
 
-        /*Adding responsiveness*/
-        @media (max-width: 1200px) {
-            html {
-                font-size: 15px;
-            }
-
-            .right {
-                width: 30%;
-            }
-        }
-
-        @media (max-width: 1000px) {
-            html {
-                font-size: 15px;
-            }
-
-            .right {
-                width: 35%;
-            }
-        }
-
-        @media (max-width: 900px) {
-            html {
-                font-size: 14px;
-            }
-
-            .right {
-                width: 40%;
-            }
-        }
-
-        @media (max-width: 600px) {
-            html {
-                font-size: 12px;
-            }
-
+        /* ── Responsive ── */
+        @media (max-width: 720px) {
             .App {
                 height: auto;
+                min-height: 100vh;
                 flex-direction: column-reverse;
+                padding: 1.5rem 0;
+                gap: 1.25rem;
             }
 
             .table {
-                margin: 1rem 0;
-                width: 100%;
-                height: 100vw;
+                width: min(92vw, 92vh);
+                height: min(92vw, 92vh);
             }
 
             .right {
-                height: auto;
-                margin: 1rem 0;
-                width: 80%;
+                width: min(92vw, 360px);
             }
 
-            .right .result-board {
-                padding: 1rem;
-            }
+            .brand span { font-size: 2.4rem; }
         }
     </style>
 </head>
@@ -241,8 +259,16 @@
                 <span>Tic </span><span>Tac </span><span>Toe</span>
             </div>
             <div class="result-board">
-                <p>Player(X): </p><span class="score" id="X-score">0</span>
-                <p>Player(O): </p><span class="score" id="O-score">0</span>
+                <div class="score-row">
+                    <p class="score-label x">Player X</p>
+                    <span class="score" id="X-score">0</span>
+                </div>
+                <hr class="divider">
+                <div class="score-row">
+                    <p class="score-label o">Player O</p>
+                    <span class="score" id="O-score">0</span>
+                </div>
+                <hr class="divider">
                 <div class="options">
                     <button class="play-again-btn">Play Again</button>
                     <p class="mode">Switch Mode: <i class="fas fa-user-ninja"></i>2P</p>
@@ -266,7 +292,6 @@
             resetBoard(board);
 
             const bestMove = (board, turn) => {
-                console.log("calculating move");
                 let bestScore = -Infinity;
                 let move;
                 for (let x = 0; x < 3; x++) {


### PR DESCRIPTION
## Summary

- Switch game board from flex-wrap to CSS Grid for clean 3×3 layout
- Add CSS custom properties for a consistent dark-theme color palette
- Round corners on board and cells; add hover highlight on empty squares (`:hover:not(:has(p))`)
- Restructure score panel: side-by-side `Player X / Player O` labels with score values and hairline dividers
- Add Inter (Google Fonts) for body text; keep Luckiest Guy for X/O pieces
- Polish Play Again button (tinted gold background on hover) and mode switcher (color transition on hover)
- Simplify responsive breakpoints to a single 720px query with column-reverse layout
- Remove stray `console.log` from AI move calculator

## Validation

Open `index.html` in a browser (no build step needed — it's a single-file PWA):

```
# serve locally if needed
npx serve .
```

- Board renders as a clean 3×3 grid with rounded cells
- Hovering an empty cell shows a subtle highlight; occupied cells do not highlight
- Score panel shows "Player X / Player O" labels in cyan/pink with numeric scores at right
- Play Again button and mode switcher have smooth hover transitions
- Switching to 1P mode and playing works as before (AI minimax unchanged)
- At ≤720px viewport the layout stacks vertically (board below, panel above)