### PR TITLE
fix: check minimax winner before draw to score winning last move correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,14 +288,12 @@
 
 
             const minimax = (board, depth, isMaximizing) => {
-                if (
-                    board.every(row => !row.includes(''))
-                ) {
-                    return 0;
-                }
                 let hasWinner = someOneWins(board);
                 if (hasWinner.result) {
                     return hasWinner.player === "O" ? 10 - depth : -10 + depth;
+                }
+                if (board.every(row => !row.includes(''))) {
+                    return 0;
                 }
 
                 if (isMaximizing) {


### PR DESCRIPTION
## Summary

- Fixed a bug in the `minimax` function where a full-board draw check ran before the winner check, causing a winning last move to be incorrectly scored as 0 (draw) instead of a win/loss score.
- Reordered so the winner is checked first, then the draw (full board) condition.

## Test plan

- Open the game in a browser with AI mode enabled (click "Switch Mode").
- Play until the AI has only one winning move available on the last empty square — the AI should take it and win rather than treating it as a draw.
- Verify the score increments correctly for Player O (AI) on a game won on the final square.

🤖 Generated with [Claude Code](https://claude.com/claude-code)