### PR TITLE
feat: restyle app with purple primary theme (#6c63ff)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Free portable 2P tic tac toe game">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta name="theme-color" content="#145181">
+    <meta name="theme-color" content="#6c63ff">
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon"
         href="https://cdn3.iconfinder.com/data/icons/essenstial-ultimate-ui/64/tic_tac_toe-512.png">
@@ -37,7 +37,7 @@
             display: flex;
             justify-content: space-between;
             flex-wrap: wrap;
-            background-color: #fdcb6e;
+            background-color: #6c63ff;
             align-content: space-between;
         }
 
@@ -58,7 +58,7 @@
             display: flex;
             background-color: #1e2a35;
             font-size: 1.5rem;
-            color: #ffeaa7;
+            color: #e8e4ff;
             justify-content: space-around;
             flex-direction: column;
             align-items: center;
@@ -72,7 +72,7 @@
         .play-again-btn {
             background-color: transparent;
             padding: 0.3rem 0.6rem;
-            border: 1px solid #fdcb6e;
+            border: 1px solid #6c63ff;
             font-size: 1.2rem;
             font-family: cursive;
             color: #f0f0f0;
@@ -138,7 +138,7 @@
         }
 
         .brand span:nth-child(3) {
-            color: #fdcb6e;
+            color: #6c63ff;
         }
 
         @keyframes fade {

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Tic Tac Toe",
   "short_name": "Tic Tac Toe",
-  "theme_color": "#145181",
-  "background_color": "#2196f3",
+  "theme_color": "#6c63ff",
+  "background_color": "#6c63ff",
   "display": "standalone",
   "Scope": "/",
   "start_url": "/",


### PR DESCRIPTION
## Summary

- Replace gold accent (`#fdcb6e`) with purple (`#6c63ff`) as the new primary color throughout the app
- Updated elements: game board background, play-again button border, brand "Toe" text, result-board text color (`#ffeaa7` → `#e8e4ff` light lavender)
- Updated PWA manifest `theme_color` and `background_color` to `#6c63ff`
- Updated HTML meta `theme-color` to `#6c63ff`
- Player X (cyan `#43dde6`) and Player O (pink `#fc5185`) colors preserved for game clarity

## Validation

Open `index.html` in a browser and verify:
- Game board grid lines/background are purple
- "Toe" in the title brand is purple
- Play Again button has a purple border
- Score text appears in light lavender
- Browser/PWA chrome color matches purple theme
- Player X still renders cyan, Player O still renders pink