### PR TITLE
style: restyle app with golden yellow primary theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Free portable 2P tic tac toe game">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <meta name="theme-color" content="#145181">
+    <meta name="theme-color" content="#fdcb6e">
     <link rel="manifest" href="manifest.json">
     <link rel="apple-touch-icon"
         href="https://cdn3.iconfinder.com/data/icons/essenstial-ultimate-ui/64/tic_tac_toe-512.png">
@@ -24,7 +24,7 @@
             display: flex;
             justify-content: space-around;
             align-items: center;
-            background-color: #263442;
+            background-color: #1a0e00;
         }
 
         html::-webkit-scrollbar {
@@ -56,7 +56,7 @@
             box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.5);
             border-radius: 5px;
             display: flex;
-            background-color: #1e2a35;
+            background-color: #231300;
             font-size: 1.5rem;
             color: #ffeaa7;
             justify-content: space-around;
@@ -94,7 +94,7 @@
         }
 
         .square {
-            background-color: #263442;
+            background-color: #2c1a00;
             cursor: pointer;
             width: calc(calc(100% / 3) - 0.2rem);
             height: calc(calc(100% / 3) - 0.2rem);
@@ -130,15 +130,15 @@
         }
 
         .brand span:nth-child(1) {
-            color: #fc5185;
+            color: #f39c12;
         }
 
         .brand span:nth-child(2) {
-            color: #43dde6;
+            color: #fdcb6e;
         }
 
         .brand span:nth-child(3) {
-            color: #fdcb6e;
+            color: #ffeaa7;
         }
 
         @keyframes fade {

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "Tic Tac Toe",
   "short_name": "Tic Tac Toe",
-  "theme_color": "#145181",
-  "background_color": "#2196f3",
+  "theme_color": "#fdcb6e",
+  "background_color": "#1a0e00",
   "display": "standalone",
   "Scope": "/",
   "start_url": "/",


### PR DESCRIPTION
## Summary

- Restyle the Tic Tac Toe PWA with golden yellow (`#fdcb6e`) as the new primary color
- App background changed to deep warm dark (`#1a0e00`) so golden yellow grid pops
- Squares changed to warm dark brown (`#2c1a00`) for consistent warm contrast
- Result board changed to rich dark amber (`#231300`)
- Brand title colors updated to a golden family: deep amber → golden → light gold
- `theme-color` meta tag updated to `#fdcb6e`
- `manifest.json` `theme_color` and `background_color` updated to match

## Test plan

- [ ] Open `index.html` in a browser — background should be deep dark warm brown, game grid golden yellow
- [ ] Brand heading ("Tic Tac Toe") should display in warm golden tones
- [ ] Play a game — X and O markers render correctly with good contrast
- [ ] Result board (scores, buttons) visible against dark amber background
- [ ] On mobile, responsive layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)